### PR TITLE
Add .sb2 and .sb3 into UTExportedTypeDeclarations

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -206,6 +206,46 @@
 				<string>public.content</string>
 			</array>
 			<key>UTTypeDescription</key>
+			<string>Scratch 2.0 Project</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.softumeya.scratch2-project</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sb2</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/scratch2-project</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Scratch 3.0 Project</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.softumeya.scratch3-project</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sb3</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/scratch3-project</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
 			<string>Scratch Sprite</string>
 			<key>UTTypeIdentifier</key>
 			<string>com.softumeya.scratch-sprite</string>


### PR DESCRIPTION
Fixed the Scratch 3.0 issue you tweeted:
https://twitter.com/PyonkeeTeam/status/1349280359054147587

## Screenshots
- When Pyonkee is not installed
![IMG_0571](https://user-images.githubusercontent.com/266357/104719744-31e55980-5770-11eb-9694-2cb6080db513.jpg)

- When Pyonkee is installed
![IMG_0572](https://user-images.githubusercontent.com/266357/104719950-3dd11b80-5770-11eb-89bf-574fb1d4d46f.jpg)

- When Pyonkee with this fix is installed
![IMG_0570](https://user-images.githubusercontent.com/266357/104719850-3742a400-5770-11eb-925f-cb5423d27d8c.jpg)
