### PR TITLE
Feature/v2.13

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -33,6 +33,30 @@
 			</array>
 		</dict>
 		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Scratch2 Project</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>None</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.scratch.scratch2-project</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Scratch3 Project</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>None</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.scratch.scratch3-project</string>
+			</array>
+		</dict>
+		<dict>
 			<key>CFBundleTypeIconFiles</key>
 			<array/>
 			<key>CFBundleTypeName</key>
@@ -116,11 +140,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.12</string>
+	<string>2.13</string>
 	<key>CFBundleSignature</key>
 	<string>FAST</string>
 	<key>CFBundleVersion</key>
-	<string>0</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
@@ -217,6 +241,49 @@
 				</array>
 				<key>public.mime-type</key>
 				<string>application/scratch-sprite</string>
+			</dict>
+		</dict>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Scratch2 Project</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.scratch.scratch2-project</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sb2</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/x-scratch2</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Scratch3 Project</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.scratch.scratch3-project</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sb3</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/x.scratch.sb3</string>
 			</dict>
 		</dict>
 	</array>

--- a/Settings.bundle/Root.plist
+++ b/Settings.bundle/Root.plist
@@ -38,7 +38,7 @@
 			<key>Key</key>
 			<string>memorySize_preference</string>
 			<key>DefaultValue</key>
-			<integer>83886080</integer>
+			<integer>125829120</integer>
 			<key>MinimumValue</key>
 			<integer>41943040</integer>
 			<key>MaximumValue</key>


### PR DESCRIPTION
- Added sb2, sb3 definitions to UTImportedTypeDeclarations for not conflicting with Scratch 3
- Increased default memory allocation size